### PR TITLE
use php:7-fpm image and drop deprecated mysql php ext

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,7 +15,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
  	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
-RUN pecl install APCu geoip
+RUN pecl install APCu geoip-1.1.1
 
 ENV PIWIK_VERSION %%VERSION%%
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM php:5.6-%%VARIANT%%
+FROM php:7.1-%%VARIANT%%
 
 MAINTAINER pierre@piwik.org
 
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
- 	&& docker-php-ext-install -j$(nproc) gd mbstring mysql pdo_mysql zip ldap opcache
+ 	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
 RUN pecl install APCu geoip
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,7 +15,10 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
  	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
-RUN pecl install APCu geoip-1.1.1
+RUN pecl install APCu geoip-1.1.1 redis \
+  && rm -rf /tmp/pear
+
+RUN docker-php-ext-enable redis
 
 ENV PIWIK_VERSION %%VERSION%%
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -20,7 +20,7 @@ RUN pecl install APCu geoip-1.1.1 redis \
 
 RUN docker-php-ext-enable redis
 
-ENV PIWIK_VERSION 3.0.4
+ENV PIWIK_VERSION 3.3.0
 
 RUN curl -fsSL -o piwik.tar.gz \
       "https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz" \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -15,7 +15,10 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
  	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
-RUN pecl install APCu geoip-1.1.1
+RUN pecl install APCu geoip-1.1.1 redis \
+  && rm -rf /tmp/pear
+
+RUN docker-php-ext-enable redis
 
 ENV PIWIK_VERSION 3.0.4
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -17,7 +17,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
 
 RUN pecl install APCu geoip
 
-ENV PIWIK_VERSION 3.0.3
+ENV PIWIK_VERSION 3.0.4
 
 RUN curl -fsSL -o piwik.tar.gz \
       "https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz" \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-apache
+FROM php:7.1-apache
 
 MAINTAINER pierre@piwik.org
 
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y \
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
- 	&& docker-php-ext-install -j$(nproc) gd mbstring mysql pdo_mysql zip ldap opcache
+ 	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
-RUN pecl install APCu geoip
+RUN pecl install APCu geoip-1.1.1
 
 ENV PIWIK_VERSION 3.0.4
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -15,7 +15,10 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
  	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
-RUN pecl install APCu geoip-1.1.1
+RUN pecl install APCu geoip-1.1.1 redis \
+	&& rm -rf /tmp/pear
+
+RUN docker-php-ext-enable redis
 
 ENV PIWIK_VERSION 3.0.4
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -16,11 +16,11 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
  	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
 RUN pecl install APCu geoip-1.1.1 redis \
-	&& rm -rf /tmp/pear
+  && rm -rf /tmp/pear
 
 RUN docker-php-ext-enable redis
 
-ENV PIWIK_VERSION 3.0.4
+ENV PIWIK_VERSION 3.3.0
 
 RUN curl -fsSL -o piwik.tar.gz \
       "https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz" \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-fpm
+FROM php:7.1-fpm
 
 MAINTAINER pierre@piwik.org
 
@@ -15,7 +15,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
  	&& docker-php-ext-install -j$(nproc) gd mbstring pdo_mysql zip ldap opcache
 
-RUN pecl install APCu geoip
+RUN pecl install APCu geoip-1.1.1
 
 ENV PIWIK_VERSION 3.0.4
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -17,7 +17,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --w
 
 RUN pecl install APCu geoip
 
-ENV PIWIK_VERSION 3.0.3
+ENV PIWIK_VERSION 3.0.4
 
 RUN curl -fsSL -o piwik.tar.gz \
       "https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz" \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -67,8 +67,9 @@ for variant in "${variants[@]}"; do
 	fi
 
 	cat <<-EOE
+
 		Tags: $(join ', ' "${variantAliases[@]}")
 		GitCommit: $commit
-		Directory: $version/$variant
+		Directory: $variant
 	EOE
 done


### PR DESCRIPTION
fixes #45 . mysql php-ext is deprecated with php7 and one of the recommended replacements is pdo_mysql.