### PR TITLE
Add "set -e" to second RUN block

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -55,7 +55,8 @@ RUN set -ex; \
 
 ENV PIWIK_VERSION %%VERSION%%
 
-RUN curl -fsSL -o piwik.tar.gz \
+RUN set -ex; \
+	curl -fsSL -o piwik.tar.gz \
 		"https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz"; \
 	curl -fsSL -o piwik.tar.gz.asc \
 		"https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz.asc"; \
@@ -68,7 +69,8 @@ RUN curl -fsSL -o piwik.tar.gz \
 
 COPY php.ini /usr/local/etc/php/php.ini
 
-RUN curl -fsSL -o /usr/src/piwik/misc/GeoIPCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
+RUN set -ex; \
+	curl -fsSL -o /usr/src/piwik/misc/GeoIPCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
 	gunzip /usr/src/piwik/misc/GeoIPCity.dat.gz
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -55,7 +55,8 @@ RUN set -ex; \
 
 ENV PIWIK_VERSION 3.3.0
 
-RUN curl -fsSL -o piwik.tar.gz \
+RUN set -ex; \
+	curl -fsSL -o piwik.tar.gz \
 		"https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz"; \
 	curl -fsSL -o piwik.tar.gz.asc \
 		"https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz.asc"; \
@@ -68,7 +69,8 @@ RUN curl -fsSL -o piwik.tar.gz \
 
 COPY php.ini /usr/local/etc/php/php.ini
 
-RUN curl -fsSL -o /usr/src/piwik/misc/GeoIPCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
+RUN set -ex; \
+	curl -fsSL -o /usr/src/piwik/misc/GeoIPCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
 	gunzip /usr/src/piwik/misc/GeoIPCity.dat.gz
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -55,7 +55,8 @@ RUN set -ex; \
 
 ENV PIWIK_VERSION 3.3.0
 
-RUN curl -fsSL -o piwik.tar.gz \
+RUN set -ex; \
+	curl -fsSL -o piwik.tar.gz \
 		"https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz"; \
 	curl -fsSL -o piwik.tar.gz.asc \
 		"https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz.asc"; \
@@ -68,7 +69,8 @@ RUN curl -fsSL -o piwik.tar.gz \
 
 COPY php.ini /usr/local/etc/php/php.ini
 
-RUN curl -fsSL -o /usr/src/piwik/misc/GeoIPCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
+RUN set -ex; \
+	curl -fsSL -o /usr/src/piwik/misc/GeoIPCity.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
 	gunzip /usr/src/piwik/misc/GeoIPCity.dat.gz
 
 COPY docker-entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Minor tidbit what was overlooked in https://github.com/matomo-org/docker-piwik/pull/80. :+1:

(Without `set -e`, this block will only fail if the final `rm xyz.tgz` fails, which will only fail if the file doesn't exist.)